### PR TITLE
Updated based on review.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CRDC datahub upload CLI is a command line interface application for end users to
 
 The application is programmed purely with python v3.11.  It depends on bento common module, http, json, aws boto3 and so on. All required python modules is listed in the file, requirements.txt, and .gitsubmodules.
 
-The application is consist of multiple python modules/classes to support mutiple functions listed below:
+The application is consist of multiple python modules/classes to support multiple functions listed below:
 
 1) Validate local and remote files by verifying md5 and size of files.
 2) Create uploading batch via crdc-datahub backend API.
@@ -17,35 +17,35 @@ The application is consist of multiple python modules/classes to support mutiple
 Major implemented modules/classes in src dir:
 
 1) uploader.py
-    This is the entry point of the command line interface.  It controls the workflow and dispatchs different requests to designated modules/classes.
+    This is the entry point of the command line interface.  It controls the workflow and dispatches different requests to designated modules/classes.
 
 2) upload_config.py
     This class manages request arguments and configurations.  It receives user's arguments, validate these arguments and store them in a dictionary.
 
 3) file_validator.py
     This class validates 1) files by checking file size and md5; 2) metadata files by checking if file existing in the data folder defined by user.
-    During the validation, it also constracts a dictionary to record file path, file size, validate result, validateion message for files.  For metadata files, it constructs a dictionary only with file path and file size.
+    During the validation, it also constructs a dictionary to record file path, file size, validate result, validation message for files.  For metadata files, it constructs a dictionary only with file path and file size.
 
 4) common/graphql_client.py
     This class hosts three clients for three graphql APIs, createTempCredential, createBatch, updateBatch.
 
 5) common/s3util.py
-    This utility class is for access designated s3 bucket with temp AWS STS credetails, and upload files to the bucket designated by uploading batch.
+    This utility class is for access designated s3 bucket with temp AWS STS credentials, and upload files to the bucket designated by uploading batch.
 
 6) file_uploader.py
     This class manages a job queue for uploading valid files (big size) and metadata files (small size) from local to S3 bucket via copier.py.
 
 7) copier.py
-    This class processes each job passed by file-uploader.py, then either upload or put into s3 buket based on upload type, file|metadata, and size via S3util.py.
+    This class processes each job passed by file-uploader.py, then either upload or put into s3 bucket based on upload type, file|metadata, and size via S3util.py.
 
 8) common/utils.py
-    This module provides utility fuctions such as dumping dictionry to tsv file, extracting exception code and messages.
+    This module provides utility functions such as dumping dictionary to tsv file, extracting exception code and messages.
 
 Usage of the CLI tool:
 
 1) Get helps command
     $ python src/uploader.py -h
-    ##Executing resullts:
+    ##Executing results:
     Command line arguments / configuration
     -a --api-url, API endpoint URL, required
     -k --token, API token string, required

--- a/configs/uploader-file-config.example.yml
+++ b/configs/uploader-file-config.example.yml
@@ -19,5 +19,9 @@ Config:
     md5-field: original_md5sum
     #file uploading retries
     retries: 3
+    # if overwrite existed file
+    overwrite: true
+    # if only run file validation without uploading
+    dryrun: false
 
 

--- a/configs/uploader-metadat-config.example.yml
+++ b/configs/uploader-metadat-config.example.yml
@@ -13,4 +13,9 @@ Config:
     intention: New
     #file uploading retries
     retries: 3
+     # if overwrite existed file
+    overwrite: true
+    # if only run file validation without uploading
+    dryrun: false
+
    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyyaml=
 boto3
 requests
-tqdm
 requests_aws4auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml=
+pyyaml
 boto3
 requests
 requests_aws4auth

--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -1,9 +1,14 @@
 #define constants, enums, etc.
 #config 
 UPLOAD_TYPE = "type"
-UPLOAD_TYPES = ["file", "metadata"]
+TYPE_FILE ="file"
+TYPE_MATE_DATA= "metadata"
+UPLOAD_TYPES = [TYPE_FILE, TYPE_MATE_DATA]
 INTENTION = "intention"
-INTENTIONS =  ["New", "Update", "Delete"]
+INTENTION_NEW = "New"
+INTENTION_UPDATE = "Update"
+INTENTION_DELETE = "Delete"
+INTENTIONS = [INTENTION_NEW, INTENTION_UPDATE, INTENTION_DELETE]
 FILE_NAME_FIELD = "name-field"
 FILE_NAME_DEFAULT = "file_name"  #match data model file name 
 FILE_PATH = "file_path"
@@ -18,6 +23,8 @@ PRE_MANIFEST = "manifest"
 FILE_DIR = "data"
 S3_BUCKET = "bucket"
 RETRIES = "retries"
+OVERWRITE = "overwrite"
+DRY_RUN = "dryrun"
 
 #file validation 
 FILE_INVALID_REASON = "invalid_reason"

--- a/src/common/graphql_client.py
+++ b/src/common/graphql_client.py
@@ -16,7 +16,7 @@ class APIInvoker:
         self.log = get_logger('GraphQL API')
         self.type = configs.get(UPLOAD_TYPE)
 
-    #1) get sts temp creadential for file/metadata uploading to S3 bucket
+    #1) get sts temp credential for file/metadata uploading to S3 bucket
     def get_temp_credential(self):
         self.cred = None
         body = f"""
@@ -33,25 +33,25 @@ class APIInvoker:
             status = response.status_code
             self.log.info(f"get_temp_credential response status code: {status}.")
             if status == 200: 
-                results = json.loads(response.content)
+                results = response.json()
                 if results.get("errors"):
-                    self.log.error(f'Get temp creadential failed: {results.get("errors").get("message")}!')  
+                    self.log.error(f'Get temp credential failed: {results.get("errors").get("message")}!')  
                     return False
                 else:
                     self.cred = results.get("data").get("createTempCredentials")
                     return True  
             else:
-                self.log.error(f'Get temp creadential failed with status code: {status}.')
+                self.log.error(f'Get temp credential failed with status code: {status}.')
                 return False
 
         except Exception as e:
             self.log.debug(e)
-            self.log.exception(f'Get temp creadential failed! {get_exception_msg()}')
+            self.log.exception(f'Get temp credential failed! {get_exception_msg()}')
             return False
 
 
     #2) create upload batch
-    def create_bitch(self, file_array):
+    def create_batch(self, file_array):
         self.new_batch = None
         #adjust file list to match the graphql param.
         file_array = json.dumps(file_array).replace("\"fileName\"", "fileName").replace("\"size\"", "size")
@@ -81,7 +81,7 @@ class APIInvoker:
             status = response.status_code
             self.log.info(f"update bitch response status code: {status}.")
             if status == 200: 
-                results = json.loads(response.content)
+                results = response.json()
                 if results.get("errors"):
                         self.log.error(f'Create batch failed: {results.get("errors")[0].get("message")}!') 
                 else:
@@ -101,7 +101,7 @@ class APIInvoker:
             return False
 
     #3) update upload batch
-    def update_bitch(self, batchID, uploaded_files):
+    def update_batch(self, batchID, uploaded_files):
         self.batch = None
         #adjust file list to match the graphql param.
         file_array = json.dumps(uploaded_files).replace("\"fileName\"", "fileName").replace("\"succeeded\"", "succeeded").replace("\"errors\"", "errors")
@@ -127,7 +127,7 @@ class APIInvoker:
             status = response.status_code
             self.log.info(f"update bitch response status code: {status}.")
             if status == 200: 
-                results = json.loads(response.content)
+                results = response.json()
                 if results.get("errors"):
                         self.log.error(f'Update batch failed: {results.get("errors")[0].get("message")}!') 
                 else:

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -12,13 +12,13 @@ class S3Bucket:
     def __init__(self):
         self.log = get_logger('S3 Bucket')
 
-    def set_s3_client(self, bucket, creadentials):
+    def set_s3_client(self, bucket, credentials):
         self.bucket_name = bucket
-        self.credential = creadentials
+        self.credential = credentials
         session = boto3.session.Session(
-            aws_access_key_id=creadentials[ACCESS_KEY_ID],
-            aws_secret_access_key=creadentials[SECRET_KEY],
-            aws_session_token=creadentials[SESSION_TOKEN]
+            aws_access_key_id=credentials[ACCESS_KEY_ID],
+            aws_secret_access_key=credentials[SECRET_KEY],
+            aws_session_token=credentials[SESSION_TOKEN]
         )
         self.client = session.client('s3')
         self.s3 = session.resource('s3')

--- a/src/copier.py
+++ b/src/copier.py
@@ -7,7 +7,7 @@ from bento.common.utils import get_logger, format_bytes, removeTrailingSlash, ge
 
 from common.graphql_client import APIInvoker
 from common.s3util import S3Bucket
-from common.constants import UPLOAD_TYPE, UPLOAD_TYPES,FILE_NAME_DEFAULT, FILE_SIZE_DEFAULT, TEMP_CREDENTIAL, FILE_PATH, ERRORS
+from common.constants import UPLOAD_TYPE, TYPE_FILE, TYPE_MATE_DATA, FILE_NAME_DEFAULT, FILE_SIZE_DEFAULT, TEMP_CREDENTIAL, FILE_PATH, ERRORS
 from common.utils import get_exception_msg
 class Copier:
 
@@ -127,7 +127,7 @@ class Copier:
 
     def _upload_obj(self, org_url, key, org_size):
         
-        if self.type == UPLOAD_TYPES[0] or org_size > self.SINGLE_PUT_LIMIT: #study files upload (big files)
+        if self.type == TYPE_FILE or org_size > self.SINGLE_PUT_LIMIT: #study files upload (big files)
             parts = int(org_size) // self.MULTI_PART_CHUNK_SIZE
             chunk_size = self.MULTI_PART_CHUNK_SIZE if parts < self.PARTS_LIMIT else int(org_size) // self.PARTS_LIMIT
             t_config = TransferConfig(multipart_threshold=self.MULTI_PART_THRESHOLD,

--- a/src/file_uploader.py
+++ b/src/file_uploader.py
@@ -38,7 +38,6 @@ class FileUploader:
 
         # Statistics
         self.files_processed = 0
-        self.files_skipped = 0
         self.files_failed = 0
 
     @staticmethod
@@ -70,22 +69,16 @@ class FileUploader:
         while file_queue:
             job = file_queue.popleft()
             file_info = job[self.INFO]
-            #skip invalid file
-            file_skip = False if not file_info.get(SUCCEEDED) else True
             job[self.TTL] -= 1
-            if file_skip == False:
-                self.files_processed += 1
-                result = self.copier.copy_file(file_info, self.overwrite, self.dryrun)
-                if result.get(Copier.STATUS):
-                    file_info[SUCCEEDED] = True
-                    file_info[ERRORS] = None
-                else:
-                    self._deal_with_failed_file(job, file_queue)
-            else:
-                self.files_skipped += 1
-                file_info[SUCCEEDED] = False
 
-        self.log.info(f'Files skipped: {self.files_skipped}')
+            self.files_processed += 1
+            result = self.copier.copy_file(file_info, self.overwrite, self.dryrun)
+            if result.get(Copier.STATUS):
+                file_info[SUCCEEDED] = True
+                file_info[ERRORS] = None
+            else:
+                self._deal_with_failed_file(job, file_queue)
+
         self.log.info(f'Files processed: {self.files_processed}')
         self.log.info(f'Files not found: {len(self.copier.files_not_found)}')
         self.log.info(f'Files copied: {self.copier.files_copied}')

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -53,7 +53,10 @@ class FileValidator:
                 self.log.critical(f'manifest file is not valid!')
                 return False
             return self.validate_size_md5()
-
+        
+        else:
+            self.log.critical(f'Invalid uploading type, {self.uploadType}!')
+            return False
         return True
 
     #validate file's size and md5 against ree-manifest.   
@@ -65,7 +68,8 @@ class FileValidator:
         for info in self.files_info:
             invalid_reason = ""
             file_path = os.path.join(self.file_dir, info[FILE_NAME_DEFAULT])
-            size_info = 0 if not info[FILE_SIZE_DEFAULT] or not info[FILE_SIZE_DEFAULT].isdigit() else int(info[FILE_SIZE_DEFAULT])
+            size = info.get(FILE_SIZE_DEFAULT)
+            size_info = 0 if not size or not size.isdigit() else int(size)
             info[FILE_SIZE_DEFAULT]  = size_info #convert to int
 
             if not os.path.isfile(file_path):
@@ -77,7 +81,7 @@ class FileValidator:
             
             file_size = os.path.getsize(file_path)
             if file_size != size_info:
-                invalid_reason += f"Real file size {file_size} of file {info[FILE_NAME_DEFAULT]} does not match with that in manifet {info[FILE_SIZE_DEFAULT]}!"
+                invalid_reason += f"Real file size {file_size} of file {info[FILE_NAME_DEFAULT]} does not match with that in manifest {info[FILE_SIZE_DEFAULT]}!"
                 self.fileList.append({FILE_NAME_DEFAULT: info.get(FILE_NAME_DEFAULT), FILE_PATH: file_path, FILE_SIZE_DEFAULT: file_size, FILE_INVALID_REASON: invalid_reason})
                 self.invalid_count += 1
                 continue

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -4,7 +4,7 @@ import csv
 import os
 import glob
 
-from common.constants import UPLOAD_TYPE, UPLOAD_TYPES, FILE_NAME_DEFAULT, FILE_SIZE_DEFAULT, MD5_DEFAULT, \
+from common.constants import UPLOAD_TYPE, TYPE_FILE, TYPE_MATE_DATA, FILE_NAME_DEFAULT, FILE_SIZE_DEFAULT, MD5_DEFAULT, \
      FILE_DIR, FILE_MD5_FIELD, PRE_MANIFEST, FILE_NAME_FIELD, FILE_SIZE_FIELD, FILE_INVALID_REASON, FILE_PATH, SUCCEEDED, ERRORS
 from common.utils import clean_up_key_value, clean_up_strs, get_exception_msg
 from bento.common.utils import get_logger, get_md5
@@ -33,7 +33,7 @@ class FileValidator:
             return False
         
         
-        if self.uploadType == UPLOAD_TYPES[1]: #metadata
+        if self.uploadType == TYPE_MATE_DATA: #metadata
             txt_files = glob.glob('{}/*.txt'.format(self.file_dir ))
             tsv_files = glob.glob('{}/*.tsv'.format(self.file_dir ))
             file_list = txt_files + tsv_files
@@ -47,7 +47,7 @@ class FileValidator:
                 #metadata file dictionary: {FILE_NAME_DEFAULT: None, FILE_SIZE_DEFAULT: None}
                 self.fileList.append({FILE_NAME_DEFAULT:filename, FILE_PATH: filepath, FILE_SIZE_DEFAULT: size})
 
-        elif self.uploadType == UPLOAD_TYPES[0]: #file
+        elif self.uploadType == TYPE_FILE: #file
             if not os.path.isfile(self.pre_manifest):
                 self.log.critical(f'manifest file is not valid!')
                 return False

--- a/src/upload_config.py
+++ b/src/upload_config.py
@@ -1,35 +1,12 @@
 import argparse
 import os
 import yaml
+import sys
 from common.constants import UPLOAD_TYPE, UPLOAD_TYPES,INTENTION, INTENTIONS, FILE_NAME_DEFAULT, FILE_SIZE_DEFAULT, MD5_DEFAULT, \
-    API_URL, TOKEN, SUBMISSION_ID, FILE_DIR, FILE_MD5_FIELD, PRE_MANIFEST, FILE_NAME_FIELD, FILE_SIZE_FIELD, RETRIES
+    API_URL, TOKEN, SUBMISSION_ID, FILE_DIR, FILE_MD5_FIELD, PRE_MANIFEST, FILE_NAME_FIELD, FILE_SIZE_FIELD, RETRIES, OVERWRITE, \
+        DRY_RUN, TYPE_FILE, TYPE_MATE_DATA, INTENTION_NEW
 from bento.common.utils import get_logger
 from common.utils import clean_up_key_value
-
-
-#requirements of the ticket CRDCDH-13:
-UPLOAD_HELP = """
-Command line arguments / configuration
--a --api-url, API endpoint URL, required
--k --token, API token string, required
--u --submission, submission ID, required
--t --type, valid value in [“file”, “metadata”], required
--d --data, folder that contains either data files (type = “file”) or metadata (TSV/TXT) files (type = “metadata”), required
--c --config, configuration file path, can potentially contain all above parameters, preferred
--r --retries, file uploading retries, integer, optional, default value is 3
-Following arguments are needed to read important data from manifest, conditional required when type = “file”
-
--m --manifest, path to manifest file, conditional required when type = “file”
--n --name-field
--s --size-field
--m --md5-field
-Following argument is needed when type = "metadata"
-
--i --intention, valid value in [“New”, “Update”, “Delete”], conditional required when type = “metadata”, default to “new”
-CLI Argument and configuration module will validate and combine parameters from CLI and/or config file
-If config_file is given, then everything else is potentially optional (if it’s included in config file)
-Some arguments are only needed for type = “file” or type = “metadata”, e.g., —intention, —manifest
-"""
 
 class Config():
     def __init__(self):
@@ -38,24 +15,26 @@ class Config():
         parser.add_argument('-a', '--api-url', help='API endpoint URL, required')
         parser.add_argument('-k', '--token', help='API token string, required')
         parser.add_argument('-u', '--submission', help='submission ID, required')
-        parser.add_argument('-t', '--type', help='valid value in [“file”, “metadata”], required')
+        parser.add_argument('-t', '--type', choices=UPLOAD_TYPES, help='valid value in [“file”, “metadata”], required')
         parser.add_argument('-d', '--data', help='folder that contains either data files (type = “file”) or metadata (TSV/TXT) files (type = “metadata”), required')
-        
+        parser.add_argument('--overwrite', default=False, type=bool, help='Overwrite file even same size file already exists at destination, optional, default is false')
+        parser.add_argument('--dryrun', default=False, type=bool, help='Only check original file, won\'t copy any files, optional, default is false')
         #args for file type
         parser.add_argument('-f', '--manifest', help='path to manifest file, conditional required when type = “file"')
         parser.add_argument('-n', '--name-field', help='header file name in manifest, optional, default value is "file_name"')
         parser.add_argument('-s', '--size-field', help='header file size in manifest, optional, default value is "file_size"')
-        parser.add_argument('-m', '--md5-field', help='header file size nin manifest, optional, default value is "md5sum"')
-        parser.add_argument('-r', '--retries', help='file uploading retries, optional, default value is 3')
+        parser.add_argument('-m', '--md5-field', choices=INTENTIONS ,help='header file size nin manifest, optional, default value is "md5sum"')
+        parser.add_argument('-r', '--retries', default=3, type=int, help='file uploading retries, optional, default value is 3')
         #args for metadata type
         parser.add_argument('-i', '--intention,', help='valid value in [“New”, “Update”, “Delete”], conditional required when type = “metadata”, default to “new”')
 
         #for better user experience, using configuration file to pass all args above
         parser.add_argument('-c', '--config', help='configuration file, can potentially contain all above parameters, optional')
-        #parser.add_argument('config_file', help='configuration file, contain all parameters without input args one by one, preferred')
        
         args = parser.parse_args()
         self.data = {}
+
+
         if args.config and os.path.isfile(args.config.strip()):
             with open(args.config.strip()) as c_file:
                 self.data = yaml.safe_load(c_file)['Config']
@@ -72,7 +51,8 @@ class Config():
                     self.data[key] = value
             elif value is not None:
                 self.data[key] = value
-
+    # although some args are validated, 
+    # we still need to validate all in case user only uses config file
     def validate(self):
         if len(self.data)== 0:
             return False
@@ -104,6 +84,16 @@ class Config():
         else:
             self.data[RETRIES] =int(retry) 
 
+        overwrite = self.data.get(OVERWRITE, False) #default value is False
+        if isinstance(overwrite, str):
+            overwrite = True if overwrite.lower() == "true" else False
+            self.data[OVERWRITE] = overwrite
+
+        dry_run = self.data.get(DRY_RUN, False) #default value is False
+        if isinstance(dry_run, str):
+            dry_run = True if overwrite.lower() == "true" else False
+            self.data[OVERWRITE] = dry_run
+
         type = self.data.get(UPLOAD_TYPE)
         if type is None:
             self.log.critical(f'upload type is required!')
@@ -112,7 +102,7 @@ class Config():
             self.log.critical(f'{type} is not valid uploading type!')
             return False
         else:
-            if type == UPLOAD_TYPES[0]: #file
+            if type == TYPE_FILE: #file
                 #check manifest
                 manifest = self.data.get(PRE_MANIFEST)
                 if manifest is None:
@@ -124,22 +114,22 @@ class Config():
                 
                 self.data[PRE_MANIFEST]  = manifest
                 #check header names in manifest file
-                file_name_hearder= self.data.get(FILE_NAME_FIELD)
-                if file_name_hearder is None:
+                file_name_header= self.data.get(FILE_NAME_FIELD)
+                if file_name_header is None:
                     self.data[FILE_NAME_FIELD] = FILE_NAME_DEFAULT
 
-                file_size_hearder = self.data.get(FILE_SIZE_FIELD)
-                if file_size_hearder is None:
+                file_size_header = self.data.get(FILE_SIZE_FIELD)
+                if file_size_header is None:
                     self.data[FILE_SIZE_FIELD] = FILE_SIZE_DEFAULT
 
                 md5_header = self.data.get(FILE_MD5_FIELD)
                 if  md5_header is None:
                     self.data[FILE_MD5_FIELD] = MD5_DEFAULT
 
-            elif type == UPLOAD_TYPES[1]: #metadata
+            elif type == TYPE_MATE_DATA: #metadata
                 #check intention
-                # based on requirement in ticket 456, in MVPM2 the intention is always New
-                self.data[INTENTION] = INTENTIONS[0] #New
+                # based on requirement in ticket 456, in MVP2 M2 the intention is always New
+                self.data[INTENTION] = INTENTION_NEW #New
         
                 # intention = self.data.get(INTENTION)
                 # if intention is None:

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -35,60 +35,64 @@ def controller():
         print("Failed to upload files: found invalid file(s)!  Please check log file in tmp folder for details.")
         return 1
     file_list = validator.fileList
-    
-    #step 3: create a batch
-    apiInvoker = APIInvoker(configs)
-    file_array = [{"fileName": item[FILE_NAME_DEFAULT], "size": item[FILE_SIZE_DEFAULT]} for item in file_list]
-    newBatch = None
-    if apiInvoker.create_batch(file_array):
-        newBatch = apiInvoker.new_batch
-        if not newBatch.get(BATCH_BUCKET) or not newBatch[FILE_PREFIX] or not newBatch.get(BATCH_ID):
+
+    if validator.invalid_count == 0:
+        #step 3: create a batch
+        apiInvoker = APIInvoker(configs)
+        file_array = [{"fileName": item[FILE_NAME_DEFAULT], "size": item[FILE_SIZE_DEFAULT]} for item in file_list]
+        newBatch = None
+        if apiInvoker.create_batch(file_array):
+            newBatch = apiInvoker.new_batch
+            if not newBatch.get(BATCH_BUCKET) or not newBatch[FILE_PREFIX] or not newBatch.get(BATCH_ID):
+                log.error("Failed to upload files: can't create new batch!")
+                print("Failed to upload files: can't create new batch! Please check log file in tmp folder for details.")
+                return 1
+            configs[S3_BUCKET] = newBatch.get(BATCH_BUCKET)
+            configs[FILE_PREFIX] = newBatch[FILE_PREFIX]
+            configs[BATCH_ID] = newBatch.get(BATCH_ID)
+            configs[BATCH] = newBatch
+            log.info(f"New batch is created: {configs[BATCH_ID]} at {newBatch[BATCH_CREATED]}")
+        else:
             log.error("Failed to upload files: can't create new batch!")
             print("Failed to upload files: can't create new batch! Please check log file in tmp folder for details.")
             return 1
-        configs[S3_BUCKET] = newBatch.get(BATCH_BUCKET)
-        configs[FILE_PREFIX] = newBatch[FILE_PREFIX]
-        configs[BATCH_ID] = newBatch.get(BATCH_ID)
-        configs[BATCH] = newBatch
-        log.info(f"New batch is created: {configs[BATCH_ID]} at {newBatch[BATCH_CREATED]}")
-    else:
-        log.error("Failed to upload files: can't create new batch!")
-        print("Failed to upload files: can't create new batch! Please check log file in tmp folder for details.")
-        return 1
 
-    #step 4: get aws sts temp credential for uploading files to s3 bucket.
-    if not apiInvoker.get_temp_credential():
-        log.error("Failed to upload files: can't get temp credential!")
-        print("Failed to upload files: can't get temp credential! Please check log file in tmp folder for details.")
-        #set fileList for update batch
-        file_array = [{"fileName": item[FILE_NAME_DEFAULT], "succeeded": False, "errors": ["Failed to upload files: can't get temp credential!"]} for item in file_list]
-    else:
-        temp_credential = apiInvoker.cred
-        configs[TEMP_CREDENTIAL] = temp_credential
-
-        #step 5: upload all files to designated s3 bucket
-        loader = FileUploader(configs, file_list)
-        result = loader.upload()
-        if not result:
-            log.error("Failed to upload files: can't upload files to bucket!")
-            print("Failed to upload files: can't upload files to bucket! Please check log file in tmp folder for details.")
+        #step 4: get aws sts temp credential for uploading files to s3 bucket.
+        if not apiInvoker.get_temp_credential():
+            log.error("Failed to upload files: can't get temp credential!")
+            print("Failed to upload files: can't get temp credential! Please check log file in tmp folder for details.")
+            #set fileList for update batch
+            file_array = [{"fileName": item[FILE_NAME_DEFAULT], "succeeded": False, "errors": ["Failed to upload files: can't get temp credential!"]} for item in file_list]
         else:
-            #write filelist to tsv file and save to result dir
-            print("File uploading completed!")
-        #set fileList for update batch
-        file_array = [{"fileName": item[FILE_NAME_DEFAULT], "succeeded": item[SUCCEEDED], "errors": item[ERRORS]} for item in file_list]
+            temp_credential = apiInvoker.cred
+            configs[TEMP_CREDENTIAL] = temp_credential
+
+            #step 5: upload all files to designated s3 bucket
+            loader = FileUploader(configs, file_list)
+            result = loader.upload()
+            if not result:
+                log.error("Failed to upload files: can't upload files to bucket!")
+                print("Failed to upload files: can't upload files to bucket! Please check log file in tmp folder for details.")
+            else:
+                #write filelist to tsv file and save to result dir
+                print("File uploading completed!")
+            #set fileList for update batch
+            file_array = [{"fileName": item[FILE_NAME_DEFAULT], "succeeded": item[SUCCEEDED], "errors": item[ERRORS]} for item in file_list]
+        
+        #step 6: update the batch
+        #uploaded_files: 
+        # (fileName: String
+        # succeeded: Boolean
+        # errors: [String])
+        if apiInvoker.update_batch(newBatch[BATCH_ID], file_array):
+            batch = apiInvoker.batch
+            log.info(f"The batch is updated: {newBatch[BATCH_ID]} with new status: {batch[BATCH_STATUS]} at {batch[BATCH_UPDATED]} ")
+        else:
+            log.error(f"Failed to update batch, {newBatch[BATCH_ID]}!")
+            print(f"Failed to update batch, {newBatch[BATCH_ID]}! Please check log file in tmp folder for details.")
     
-    #step 6: update the batch
-    #uploaded_files: 
-    # (fileName: String
-    # succeeded: Boolean
-    # errors: [String])
-    if apiInvoker.update_batch(newBatch[BATCH_ID], file_array):
-        batch = apiInvoker.batch
-        log.info(f"The batch is updated: {newBatch[BATCH_ID]} with new status: {batch[BATCH_STATUS]} at {batch[BATCH_UPDATED]} ")
     else:
-        log.error(f"Failed to update batch, {newBatch[BATCH_ID]}!")
-        print(f"Failed to update batch, {newBatch[BATCH_ID]}! Please check log file in tmp folder for details.")
+        log.error(f"Found total {validator.invalid_count} files are invalid!")
     
     #step 6: #dump file_list with uploading status and errors to tmp/reports dir
     try:

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -10,45 +10,42 @@ from common.constants import UPLOAD_TYPE, S3_BUCKET, FILE_NAME_DEFAULT, FILE_SIZ
     BATCH_BUCKET, BATCH, BATCH_ID, FILE_PREFIX, TEMP_CREDENTIAL, SUCCEEDED, ERRORS, BATCH_CREATED, BATCH_UPDATED, FILE_PATH
 from common.graphql_client import APIInvoker
 from common.utils import dump_dict_to_tsv, get_exception_msg
-from upload_config import Config, UPLOAD_HELP
+from upload_config import Config
 from file_validator import FileValidator
-from file_uploader import FileLoader
+from file_uploader import FileUploader
 
 if LOG_PREFIX not in os.environ:
     os.environ[LOG_PREFIX] = 'Uploader Main'
 
 log = get_logger('FileLoader')
-# public function to received args and dispitch to different modules for different uploading types, file or metadata
-def controller():
-    #allow end user to get help from the cli
-    args = sys.argv[1:]
-    if len(args) == 1 and (args[0] == "help" or args[0] == "-help")  or args[0] == "-h":
-        print(UPLOAD_HELP)
-        return
-    
+# public function to received args and dispatch to different modules for different uploading types, file or metadata
+def controller():  
     #step 1: process args, configuration file
     config = Config()
     if not config.validate():
         log.error("Failed to upload files: missing required valid parameter(s)!")
         print("Failed to upload files: invalid parameter(s)!  Please check log file in tmp folder for details.")
-        return
+        return 1
 
     #step 2: validate file or metadata
     configs = config.data
-    upload_type = configs.get(UPLOAD_TYPE)
     validator = FileValidator(configs)
     if not validator.validate():
         log.error("Failed to upload files: found invalid file(s)!")
         print("Failed to upload files: found invalid file(s)!  Please check log file in tmp folder for details.")
-        return
+        return 1
     file_list = validator.fileList
     
     #step 3: create a batch
     apiInvoker = APIInvoker(configs)
     file_array = [{"fileName": item[FILE_NAME_DEFAULT], "size": item[FILE_SIZE_DEFAULT]} for item in file_list]
     newBatch = None
-    if apiInvoker.create_bitch(file_array):
+    if apiInvoker.create_batch(file_array):
         newBatch = apiInvoker.new_batch
+        if not newBatch.get(BATCH_BUCKET) or not newBatch[FILE_PREFIX] or not newBatch.get(BATCH_ID):
+            log.error("Failed to upload files: can't create new batch!")
+            print("Failed to upload files: can't create new batch! Please check log file in tmp folder for details.")
+            return 1
         configs[S3_BUCKET] = newBatch.get(BATCH_BUCKET)
         configs[FILE_PREFIX] = newBatch[FILE_PREFIX]
         configs[BATCH_ID] = newBatch.get(BATCH_ID)
@@ -57,9 +54,7 @@ def controller():
     else:
         log.error("Failed to upload files: can't create new batch!")
         print("Failed to upload files: can't create new batch! Please check log file in tmp folder for details.")
-        return
-    # configs[S3_BUCKET] = "crdcdh-test-submission" #test code 
-    # configs[FILE_PREFIX] = "123456/file" if upload_type == UPLOAD_TYPES[0] else "123456/metadata" #test code 
+        return 1
 
     #step 4: get aws sts temp credential for uploading files to s3 bucket.
     if not apiInvoker.get_temp_credential():
@@ -71,12 +66,12 @@ def controller():
         temp_credential = apiInvoker.cred
         configs[TEMP_CREDENTIAL] = temp_credential
 
-        #step 5: upload all files to designated s3 bukect
-        loader = FileLoader(configs, file_list)
+        #step 5: upload all files to designated s3 bucket
+        loader = FileUploader(configs, file_list)
         result = loader.upload()
         if not result:
-            log.error("Failed to upload files: can't upload files to bukect!")
-            print("Failed to upload files: can't upload files to bukect! Please check log file in tmp folder for details.")
+            log.error("Failed to upload files: can't upload files to bucket!")
+            print("Failed to upload files: can't upload files to bucket! Please check log file in tmp folder for details.")
         else:
             #write filelist to tsv file and save to result dir
             print("File uploading completed!")
@@ -88,14 +83,14 @@ def controller():
     # (fileName: String
     # succeeded: Boolean
     # errors: [String])
-    if apiInvoker.update_bitch(newBatch[BATCH_ID], file_array):
+    if apiInvoker.update_batch(newBatch[BATCH_ID], file_array):
         batch = apiInvoker.batch
         log.info(f"The batch is updated: {newBatch[BATCH_ID]} with new status: {batch[BATCH_STATUS]} at {batch[BATCH_UPDATED]} ")
     else:
         log.error(f"Failed to update batch, {newBatch[BATCH_ID]}!")
         print(f"Failed to update batch, {newBatch[BATCH_ID]}! Please check log file in tmp folder for details.")
     
-    #step 6: #dump file_list with uploading status and errors to tmp/reprots dir
+    #step 6: #dump file_list with uploading status and errors to tmp/reports dir
     try:
         file_path = f"./tmp/upload-report-{get_time_stamp()}.tsv"
         #filter out file path in the file list


### PR DESCRIPTION
Hi Ming, I updated based on most of your review except "I suggest use argparse.FileType for argument —manifest and --config, which will take care of
detecting file existence and permission etc."

The filetype is not only for validate the file path but also, read file content to _io.TextIOWrapper.   Tried yaml.dump but not work.  Since user could use config file only, we still need to validate and load the manifest file.  We have no gain for such change.   We may use it later in some pure arg app.