### PR TITLE
Strip extra "/" in logged s3 url

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -32,7 +32,7 @@ def get_exception_msg():
 
 
 """
-Dump list of dictionary to TSV file, caller needs handlw exception.
+Dump list of dictionary to TSV file, caller needs handle exception.
 :param: dict_list as list of dictionary
 :param: file_path as str
 :return: boolean

--- a/src/copier.py
+++ b/src/copier.py
@@ -78,7 +78,7 @@ class Copier:
             org_url = file_info[FILE_PATH]
             file_name = file_info[FILE_NAME_DEFAULT]
             self.log.info(f'Processing {org_url}')
-            key = f'{self.prefix}/{file_name}'.strip('/')
+            key = f'{self.prefix}/{file_name}'
             org_size = file_info[FILE_SIZE_DEFAULT]
             self.log.info(f'Original file size: {format_bytes(org_size)}.')
 
@@ -94,11 +94,11 @@ class Copier:
                 return succeed
             
             if not overwrite and self.bucket.same_size_file_exists(key, org_size):
-                self.log.info(f'File skipped: same size file exists at: "{key}"')
+                self.log.info(f'File skipped: same size file exists at: "{key.strip("/")}"')
                 self.files_exist_at_dest += 1
                 return succeed
 
-            self.log.info(f'Copying from {org_url} to s3://{self.bucket_name}/{key} ...')
+            self.log.info(f'Copying from {org_url} to s3://{self.bucket_name}/{key.strip("/")} ...')
            
             dest_size = self._upload_obj(org_url, key, org_size)
             if dest_size != org_size:

--- a/src/copier.py
+++ b/src/copier.py
@@ -78,7 +78,7 @@ class Copier:
             org_url = file_info[FILE_PATH]
             file_name = file_info[FILE_NAME_DEFAULT]
             self.log.info(f'Processing {org_url}')
-            key = f'{self.prefix}/{file_name}'
+            key = f'{self.prefix}/{file_name}'.strip('/')
             org_size = file_info[FILE_SIZE_DEFAULT]
             self.log.info(f'Original file size: {format_bytes(org_size)}.')
 

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -82,7 +82,7 @@ class FileValidator:
             file_size = os.path.getsize(file_path)
             if file_size != size_info:
                 invalid_reason += f"Real file size {file_size} of file {info[FILE_NAME_DEFAULT]} does not match with that in manifest {info[FILE_SIZE_DEFAULT]}!"
-                self.fileList.append({FILE_NAME_DEFAULT: info.get(FILE_NAME_DEFAULT), FILE_PATH: file_path, FILE_SIZE_DEFAULT: file_size, ERRORS: invalid_reason})
+                self.fileList.append({FILE_NAME_DEFAULT: info.get(FILE_NAME_DEFAULT), FILE_PATH: file_path, FILE_SIZE_DEFAULT: file_size, MD5_DEFAULT: None, SUCCEEDED: False, ERRORS: invalid_reason})
                 self.invalid_count += 1
                 continue
 

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -5,7 +5,7 @@ import os
 import glob
 
 from common.constants import UPLOAD_TYPE, TYPE_FILE, TYPE_MATE_DATA, FILE_NAME_DEFAULT, FILE_SIZE_DEFAULT, MD5_DEFAULT, \
-     FILE_DIR, FILE_MD5_FIELD, PRE_MANIFEST, FILE_NAME_FIELD, FILE_SIZE_FIELD, FILE_INVALID_REASON, FILE_PATH, SUCCEEDED, ERRORS
+     FILE_DIR, FILE_MD5_FIELD, PRE_MANIFEST, FILE_NAME_FIELD, FILE_SIZE_FIELD, FILE_PATH, SUCCEEDED, ERRORS
 from common.utils import clean_up_key_value, clean_up_strs, get_exception_msg
 from bento.common.utils import get_logger, get_md5
 
@@ -82,7 +82,7 @@ class FileValidator:
             file_size = os.path.getsize(file_path)
             if file_size != size_info:
                 invalid_reason += f"Real file size {file_size} of file {info[FILE_NAME_DEFAULT]} does not match with that in manifest {info[FILE_SIZE_DEFAULT]}!"
-                self.fileList.append({FILE_NAME_DEFAULT: info.get(FILE_NAME_DEFAULT), FILE_PATH: file_path, FILE_SIZE_DEFAULT: file_size, FILE_INVALID_REASON: invalid_reason})
+                self.fileList.append({FILE_NAME_DEFAULT: info.get(FILE_NAME_DEFAULT), FILE_PATH: file_path, FILE_SIZE_DEFAULT: file_size, ERRORS: invalid_reason})
                 self.invalid_count += 1
                 continue
 
@@ -95,7 +95,7 @@ class FileValidator:
             #calculate file md5
             md5sum = get_md5(file_path)
             if md5_info != md5sum:
-                invalid_reason += f"Real file md5 {md5sum} of file {info[FILE_NAME_DEFAULT]} does not match with that in manifet {md5_info}!"
+                invalid_reason += f"Real file md5 {md5sum} of file {info[FILE_NAME_DEFAULT]} does not match with that in manifest {md5_info}!"
                 self.fileList.append({FILE_NAME_DEFAULT: info.get(FILE_NAME_DEFAULT), FILE_PATH: file_path, FILE_SIZE_DEFAULT: file_size, MD5_DEFAULT: md5sum, SUCCEEDED: False, ERRORS: [invalid_reason]})
                 self.invalid_count += 1
                 continue

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -92,7 +92,7 @@ def controller():
             print(f"Failed to update batch, {newBatch[BATCH_ID]}! Please check log file in tmp folder for details.")
     
     else:
-        log.error(f"Found total {validator.invalid_count} files are invalid!")
+        log.error(f"Found total {validator.invalid_count} file(s) are invalid!")
     
     #step 6: #dump file_list with uploading status and errors to tmp/reports dir
     try:


### PR DESCRIPTION
Strip the "/" in  file-prefix that cause "//" in the middle of s3 url in logs.