### PR TITLE
Fixed 2955

### DIFF
--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -144,6 +144,8 @@ class S3Bucket:
     # get contents info from s3 folder
     def get_contents(self, prefix):
         contents = []
+        if not prefix.endswith('/'):
+            prefix += '/'
         try:
             for obj in self.bucket.objects.filter(Prefix=prefix):
                 # key end with ".tsv" or ".txt"

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -149,8 +149,9 @@ class S3Bucket:
         try:
             for obj in self.bucket.objects.filter(Prefix=prefix):
                 # key end with ".tsv" or ".txt"
-                if obj.key[-4:] == ".tsv" or obj.key[-4:] == ".txt":
-                    contents.append(obj.key)        
+                base, ext = os.path.splitext(obj['Key'])
+                if ext in [".tsv", ".txt"]:
+                    contents.append(obj['Key'])    
         except Exception:
             self.log.error("Failed to retrieve child metadata files.")
         finally:
@@ -169,7 +170,8 @@ class S3Bucket:
             if 'Contents' in response:
                 for obj in response['Contents']:
                     # key end with ".tsv" or ".txt"
-                    if obj['Key'][-4:] == ".tsv" or obj['Key'][-4:] == ".txt":
+                    base, ext = os.path.splitext(obj['Key'])
+                    if ext in [".tsv", ".txt"]:
                         contents.append(obj['Key'])
         except Exception:
             self.log.error("Failed to retrieve child metadata files.")

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -151,8 +151,28 @@ class S3Bucket:
                 # key end with ".tsv" or ".txt"
                 if obj.key[-4:] == ".tsv" or obj.key[-4:] == ".txt":
                     contents.append(obj.key)        
-        except Exception as e:
-            self.log.error("Failed to retrieve metadata file info")
+        except Exception:
+            self.log.error("Failed to retrieve child metadata files.")
+        finally:
+            return contents
+        
+    def get_contents_in_current_folder(self, prefix):
+        contents = []
+        if not prefix.endswith('/'):
+            prefix += '/'
+        try:
+            response = self.client.list_objects_v2(
+                Bucket=self.bucket_name,
+                Prefix=prefix,
+                Delimiter="/"
+            )
+            if 'Contents' in response:
+                for obj in response['Contents']:
+                    # key end with ".tsv" or ".txt"
+                    if obj['Key'][-4:] == ".tsv" or obj['Key'][-4:] == ".txt":
+                        contents.append(obj['Key'])
+        except Exception:
+            self.log.error("Failed to retrieve child metadata files.")
         finally:
             return contents
     

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -162,13 +162,9 @@ class S3Bucket:
         if not prefix.endswith('/'):
             prefix += '/'
         try:
-            response = self.client.list_objects_v2(
-                Bucket=self.bucket_name,
-                Prefix=prefix,
-                Delimiter="/"
-            )
-            if 'Contents' in response:
-                for obj in response['Contents']:
+            paginator = self.client.get_paginator('list_objects_v2')
+            for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
+                for obj in page.get('Contents', []):
                     # key end with ".tsv" or ".txt"
                     base, ext = os.path.splitext(obj['Key'])
                     if ext in [".tsv", ".txt"]:

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -163,7 +163,7 @@ class S3Bucket:
             prefix += '/'
         try:
             paginator = self.client.get_paginator('list_objects_v2')
-            for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix):
+            for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix, Delimiter='/' ):
                 for obj in page.get('Contents', []):
                     # key end with ".tsv" or ".txt"
                     base, ext = os.path.splitext(obj['Key'])

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -95,7 +95,7 @@ class FileValidator:
         # validate file name
         if not self.validate_file_name():
             return False
-        
+        self.field_names.append(SUBFOLDER_FILE_NAME) # add subfolder file name to field names
         for info in self.files_info:
             line_num += 1
             invalid_reason = ""
@@ -241,7 +241,6 @@ class FileValidator:
                         MD5_DEFAULT: file_info[self.configs.get(FILE_MD5_FIELD)]
                     }})
             files_info  =  list(files_dict.values())
-            self.field_names.append(SUBFOLDER_FILE_NAME) # add subfolder file name to field names
             self.manifest_rows = manifest_rows
 
         except UnicodeDecodeError as ue:

--- a/src/process_manifest.py
+++ b/src/process_manifest.py
@@ -173,7 +173,7 @@ def download_meatadata_in_s3(manifest_file_path, s3_bucket):
     bucket, prefix, manifest_file = get_s3_bucket_and_prefix(manifest_file_path)
     # download all files with ext "tsv" or "txt" in the folder of prefix from s3
     s3_bucket.set_s3_client(bucket, None)
-    metadata_files = s3_bucket.get_contents(prefix)
+    metadata_files = s3_bucket.get_contents_in_current_folder(prefix)
     for file in metadata_files:
         if not manifest_file in file:
             file_name = file.split("/")[-1]

--- a/src/process_manifest.py
+++ b/src/process_manifest.py
@@ -10,7 +10,7 @@ from common.s3util import S3Bucket
 SEPARATOR_CHAR = '\t'
 UTF8_ENCODE ='utf8'
 NODE_TYPE_NAME = 'type'
-def process_manifest_file(log, configs, has_file_id, file_infos, manifest_rows, manifest_columns, manifest_s3_url):
+def process_manifest_file(log, configs, has_file_id, file_infos, manifest_rows, manifest_s3_url):
     """
     function: process_manifest_file
     params:
@@ -19,7 +19,6 @@ def process_manifest_file(log, configs, has_file_id, file_infos, manifest_rows, 
      has_file_id: whether the pre-manifest file has file id column or not
      file_infos: the file info array of the pre-manifest file
      manifest_rows: the rows of the pre-manifest file
-     manifest_columns: the columns of the pre-manifest file
     return:
      True or False
 
@@ -40,15 +39,13 @@ def process_manifest_file(log, configs, has_file_id, file_infos, manifest_rows, 
     final_manifest_path = (str.replace(file_path, ".tsv", "-final.tsv") if ".tsv" in file_path else str.replace(file_path, ".txt", "-final.tsv")) if needFinalManifest else file_path
     file_id_name = configs[FILE_ID_FIELD]
     file_name_name = configs[FILE_NAME_FIELD]
-    if not has_file_id:
-        manifest_columns.append(file_id_name)
     result = None
     newBatch = None
     final_file_path_list = []
     file_array = []
     try:
         if needFinalManifest:
-            result = add_file_id(file_id_name, file_name_name, final_manifest_path , file_infos, manifest_rows, manifest_columns, configs.get(OMIT_DCF_PREFIX))
+            result = add_file_id(file_id_name, file_name_name, final_manifest_path , file_infos, manifest_rows, configs.get(OMIT_DCF_PREFIX))
             if not result:
                 log.info(f"Failed to add file id to the pre-manifest, {final_manifest_path }.")
                 return False
@@ -92,15 +89,16 @@ def process_manifest_file(log, configs, has_file_id, file_infos, manifest_rows, 
         return True
 
 # This method will create a new manifest file with the file id column added to the pre-manifest and internal_file_name.
-def add_file_id(file_id_name, file_name_name, final_manifest_path, file_infos, manifest_rows, manifest_columns, omit_prefix):
+def add_file_id(file_id_name, file_name_name, final_manifest_path, file_infos, manifest_rows, omit_prefix):
     output = []
     for row in manifest_rows:
         file = [file for file in file_infos if file[FILE_NAME_DEFAULT] == row[file_name_name]][0]
         file[FILE_ID_DEFAULT] = file[FILE_ID_DEFAULT] if omit_prefix == False else file[FILE_ID_DEFAULT].replace(DCF_PREFIX, "")
-        row[file_id_name] = file[FILE_ID_DEFAULT]
         row[file_name_name] = os.path.basename(file[FILE_NAME_DEFAULT])
         row[SUBFOLDER_FILE_NAME] = file[SUBFOLDER_FILE_NAME] if SUBFOLDER_FILE_NAME in file else ""
+        row[file_id_name] = file[FILE_ID_DEFAULT]
         output.append(row.values())
+    manifest_columns = manifest_rows[0].keys()
     with open(final_manifest_path, 'w', newline='') as f: 
         writer = csv.writer(f, delimiter='\t')
         writer.writerow(manifest_columns)
@@ -198,7 +196,7 @@ def get_s3_bucket_and_prefix(manifest_file_path):
     manifest_file_path = manifest_file_path.replace("s3://", "")
     temp = manifest_file_path.split("/")
     bucket = temp[0]
-    prefix = "/".join(temp[1:-1])
+    prefix = "/".join(temp[1:-1]) + "/"
     manifest_file = temp[-1]
     return bucket, prefix, manifest_file
 

--- a/src/uploader.py
+++ b/src/uploader.py
@@ -115,7 +115,7 @@ def controller():
                             # set file id to file_list
                             for i, file_info in enumerate(newBatch["files"]):
                                 file_list[i][FILE_ID_DEFAULT] = file_info.get(FILE_ID_DEFAULT)
-                        process_manifest_file(log, configs.copy(), validator.has_file_id, file_list, validator.manifest_rows, validator.field_names, s3_manifest_url)  
+                        process_manifest_file(log, configs.copy(), validator.has_file_id, file_list, validator.manifest_rows, s3_manifest_url)  
                 # stop heartbeat after uploading completed
                 if upload_heart_beater:
                     upload_heart_beater.stop()


### PR DESCRIPTION
1.  Fixed warning issue in CRDCDH 2955.
2. Fixed values interchanged between internal-file-name and file_id. [CRDCDH-2956](https://tracker.nci.nih.gov/browse/CRDCDH-2956)
3. Fixed filter s3 content with prefix to make sure it is end by "/".  [CRDCDH-2957](https://tracker.nci.nih.gov/browse/CRDCDH-2957)
4. update s3 objects filter to limited current children metadata templates. [CRDCDH-2958](https://tracker.nci.nih.gov/browse/CRDCDH-2958)