### PR TITLE
CRDCDH 3186

### DIFF
--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -260,7 +260,7 @@ class FileValidator:
                         files_dict.update({key: {
                             ARCHIVE_NAME: archive_file_name,
                             FILE_PATH: file_path,
-                            FILE_SIZE_DEFAULT: file_info.get(self.configs.get(FILE_SIZE_FIELD)),
+                            FILE_SIZE_DEFAULT: file_info.get(FILE_SIZE_DEFAULT),
                             MD5_DEFAULT: file_info.get("md5")
                         }})
             files_info  =  list(files_dict.values())


### PR DESCRIPTION
Fixed CRDCDH 3186 by minor change.  The archive_manifest file size column name is "file_size" no matter data common model.