### PR TITLE
CRDCDH-3387

### DIFF
--- a/src/common/constants.py
+++ b/src/common/constants.py
@@ -54,7 +54,7 @@ S3_START= "s3://"
 FROM_S3 = "from_s3"
 TEMP_DOWNLOAD_DIR = "tmp/download"
 
-CLI_VERSION = "4.2"
+CLI_VERSION = "4.3"
 MD5_CACHE_DIR = "tmp/md5"
 MD5_CACHE_FILE = "md5_cache.csv"
 MODIFIED_AT = "modifiedAt"

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -109,6 +109,9 @@ class S3Bucket:
     def get_object_size(self, key):
         try:
             res = self.client.head_object(Bucket=self.bucket_name, Key=key)
+            if res['ContentLength'] == 0:
+                msg = f'File {key} file size is 0.'
+                return None, msg
             return res['ContentLength'], None
         except ClientError as e:
             msg = None

--- a/src/common/s3util.py
+++ b/src/common/s3util.py
@@ -110,7 +110,7 @@ class S3Bucket:
         try:
             res = self.client.head_object(Bucket=self.bucket_name, Key=key)
             if res['ContentLength'] == 0:
-                msg = f'File {key} file size is 0.'
+                msg = f'File size is 0 for {key}'
                 return None, msg
             return res['ContentLength'], None
         except ClientError as e:

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -45,7 +45,7 @@ def dump_dict_to_tsv(dict_list, file_path):
     if not dict_list or len(dict_list) == 0:
         return False 
     keys = dict_list[0].keys()
-    with open(file_path, 'w') as output_file:
+    with open(file_path, 'w', encoding='utf-8') as output_file:
         dict_writer = csv.DictWriter(output_file, fieldnames=keys, delimiter='\t')
         dict_writer.writeheader()
         dict_writer.writerows(dict_list) 

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -204,10 +204,10 @@ class FileValidator:
             # check if file name contains non-unicode characters
             try:
                 file_name.encode('utf-8')
-                return True
             except UnicodeEncodeError:
-                is_valid = False
                 msg = f"Line {line_num}: File name {file_name} contains non-unicode characters!"
+                is_valid = False
+                self.log.error(msg)
 
 
             line_num += 1

--- a/src/file_validator.py
+++ b/src/file_validator.py
@@ -195,11 +195,20 @@ class FileValidator:
                 is_valid = False
                 self.log.error(msg)
 
-            # check if file name contains reserved or illegal characters, /, \, :, *, ?, ", <, >, and |
+            # check if file name contains reserved or illegal characters *, and |
             if re.search(r'[*|]', file_name):
                 msg = f"Line {line_num}: File name {file_name} contains invalid characters!"
                 is_valid = False
                 self.log.error(msg)
+
+            # check if file name contains non-unicode characters
+            try:
+                file_name.encode('utf-8')
+                return True
+            except UnicodeEncodeError:
+                is_valid = False
+                msg = f"Line {line_num}: File name {file_name} contains non-unicode characters!"
+
 
             line_num += 1
         self.log.info("Completed validating file names listed in pre-manifest.")

--- a/src/process_manifest.py
+++ b/src/process_manifest.py
@@ -110,6 +110,8 @@ def insert_file_id_2_children(log, configs, manifest_rows, final_file_path_list,
      # check if any tsv files in the dir of manifest file
     manifest_file = configs.get(PRE_MANIFEST)
     is_s3 = configs.get(FROM_S3, False)
+    if manifest_s3_url is None:
+        is_s3 = False
     dir = os.path.dirname(manifest_file) if not is_s3 else TEMP_DOWNLOAD_DIR
     s3_bucket = None
     try:

--- a/src/process_manifest.py
+++ b/src/process_manifest.py
@@ -99,7 +99,7 @@ def add_file_id(file_id_name, file_name_name, final_manifest_path, file_infos, m
         row[file_id_name] = file[FILE_ID_DEFAULT]
         output.append(row.values())
     manifest_columns = manifest_rows[0].keys()
-    with open(final_manifest_path, 'w', newline='') as f: 
+    with open(final_manifest_path, 'w', newline='', encoding="utf8") as f: 
         writer = csv.writer(f, delimiter='\t')
         writer.writerow(manifest_columns)
         writer.writerows(output)

--- a/src/unit_test/test_file_validator.py
+++ b/src/unit_test/test_file_validator.py
@@ -226,6 +226,22 @@ class TestValidateFileName(unittest.TestCase):
         result = self.validator.validate_file_name()
         
         self.assertTrue(result, "Should pass for file names with unicode characters")
+    
+    def test_validate_file_name_non_unicode_characters(self):
+        """Test validation passes for file names with unicode characters"""
+        # Construct an unpaired surrogate (low surrogate) character which
+        # will raise on utf-8 encoding in Python 3. This reliably simulates
+        # a non-unicode/invalid filename for the validator's check.
+        bad_char = chr(0xDC80)
+        self.validator.manifest_rows = [
+            {'file_name': bad_char + 'a.txt', 'md5sum': 'ghi789'}
+        ]
+        self.validator.configs[FILE_NAME_FIELD] = 'file_name'
+        self.validator.configs[FILE_MD5_FIELD] = 'md5sum'
+        
+        result = self.validator.validate_file_name()
+        
+        self.assertFalse(result, "Should not pass for file names with non-unicode characters")
 
     def test_validate_file_name_long_filename(self):
         """Test validation passes for very long file names"""


### PR DESCRIPTION
1) added file_name unicode validation.
2) handled the edge case when the file size is 0 in file size validation.
3) added the utf8 unicode support when generating the file-final.tsv.
4) added the utf8 unicode support when generating the submission upload-report.tsv.
5) replace the s3 download_file function with download_fileobj function to avoid error while downloading the file with non-ascii character in the file name with Windows environment.
6) Fixed the bug that when using local manifest file to load data files from the s3 bucket, the cli-uploader is trying to get the manifest file from the s3 bucket when trying to add file_id to the children.
